### PR TITLE
Fix clash with WebUI's default XYZ script

### DIFF
--- a/xyz_grid_html.py
+++ b/xyz_grid_html.py
@@ -251,7 +251,7 @@ re_range_count_float = re.compile(r"\s*([+-]?\s*\d+(?:.\d*)?)\s*-\s*([+-]?\s*\d+
 
 class Script(scripts.Script):
     def title(self):
-        return "X/Y/Z plot"
+        return "X/Y/Z HTML plot"
 
     def ui(self, is_img2img):
         current_axis_options = [x for x in axis_options if type(x) == AxisOption or type(x) == AxisOptionImg2Img and is_img2img]


### PR DESCRIPTION
The default WebUI comes with a X/Y/Z plotting script. It's called "X/Y/Z plot" and has the filename `xyz_grid.py` as just like this one. I think it would be a good idea to rename the file and also rename the script title to "X/Y/Z HTML plot."